### PR TITLE
Correção `translation missing: pt-PT.simple_form.glitch_only`

### DIFF
--- a/config/locales/simple_form.pt-PT.yml
+++ b/config/locales/simple_form.pt-PT.yml
@@ -1,6 +1,7 @@
 ---
 pt-PT:
   simple_form:
+    glitch_only: Glitch
     hints:
       account_alias:
         acct: Indica o utilizador@domínio da conta de onde pretendes migrar


### PR DESCRIPTION
Estou usando o a Ciberlandia.pt em pt-PT
E reparei que na tags que diz que é uma função só glitch
Dá o erro `translation missing: pt-PT.simple_form.glitch_only`
![imagem](https://github.com/ManufacturaInd/mastodon/assets/9739913/efd9a949-f92e-403c-8ee8-aeb9da6075d3)

E eu queria ajudar para corrigir esse erro